### PR TITLE
fix render glitch

### DIFF
--- a/src/main/java/li/cil/manual/client/manual/segment/CodeSegment.java
+++ b/src/main/java/li/cil/manual/client/manual/segment/CodeSegment.java
@@ -39,6 +39,7 @@ public final class CodeSegment extends BasicTextSegment {
         while (chars.length() > 0) {
             final String part = chars.substring(0, numChars);
             GlStateManager.color(0.25f, 0.3f, 0.5f, 1);
+            GlStateManager.enableAlpha();
             GlStateManager.pushMatrix();
             GlStateManager.translate(currentX, currentY, 0);
             GlStateManager.scale(FONT_SCALE, FONT_SCALE, FONT_SCALE);


### PR DESCRIPTION
 which happens sometimes with a page full of `code` segments

no idea what disables alpha before, but this fixes the issue seen on the screenshots

![](https://i.imgur.com/EjALoAb.png)
![](https://i.imgur.com/uBUK0Rq.png)